### PR TITLE
add strict mode support

### DIFF
--- a/requests_ntlm2/adapters.py
+++ b/requests_ntlm2/adapters.py
@@ -63,7 +63,7 @@ class HttpNtlmAdapter(HttpProxyAdapter):
         """
         Thin wrapper around requests.adapters.HTTPAdapter
         """
-        self._setup(ntlm_username, ntlm_password, ntlm_compatibility)
+        self._setup(ntlm_username, ntlm_password, ntlm_compatibility, ntlm_strict_mode)
         super(HttpNtlmAdapter, self).__init__(*args, **kwargs)
 
     def close(self):

--- a/requests_ntlm2/adapters.py
+++ b/requests_ntlm2/adapters.py
@@ -56,6 +56,7 @@ class HttpNtlmAdapter(HttpProxyAdapter):
         ntlm_username,
         ntlm_password,
         ntlm_compatibility=NtlmCompatibility.NTLMv2_DEFAULT,
+        ntlm_strict_mode=False,
         *args,
         **kwargs
     ):
@@ -70,11 +71,12 @@ class HttpNtlmAdapter(HttpProxyAdapter):
         super(HttpNtlmAdapter, self).close()
 
     @staticmethod
-    def _setup(username, password, ntlm_compatibility):
+    def _setup(username, password, ntlm_compatibility, ntlm_strict_mode):
         pool_classes_by_scheme["http"].ConnectionCls = _HTTPConnection
         pool_classes_by_scheme["https"].ConnectionCls = _HTTPSConnection
         _HTTPSConnection.set_ntlm_auth_credentials(username, password)
         _HTTPSConnection.ntlm_compatibility = ntlm_compatibility
+        _HTTPConnection.ntlm_strict_mode = ntlm_strict_mode
 
     @staticmethod
     def _teardown():

--- a/requests_ntlm2/connection.py
+++ b/requests_ntlm2/connection.py
@@ -132,7 +132,7 @@ class VerifiedHTTPSConnection(_VerifiedHTTPSConnection):
             domain=domain,
             auth_type="NTLM",
             ntlm_compatibility=self.ntlm_compatibility,
-            strict_mode=self.ntlm_strict_mode
+            ntlm_strict_mode=self.ntlm_strict_mode
         )
 
         negotiate_header = ntlm_context.get_negotiate_header()

--- a/requests_ntlm2/connection.py
+++ b/requests_ntlm2/connection.py
@@ -48,6 +48,7 @@ class HTTPSConnection(_HTTPSConnection):
 
 class VerifiedHTTPSConnection(_VerifiedHTTPSConnection):
     ntlm_compatibility = NtlmCompatibility.NTLMv2_DEFAULT
+    ntlm_strict_mode = False
 
     def __init__(self, *args, **kwargs):
         super(VerifiedHTTPSConnection, self).__init__(*args, **kwargs)
@@ -130,7 +131,8 @@ class VerifiedHTTPSConnection(_VerifiedHTTPSConnection):
             password,
             domain=domain,
             auth_type="NTLM",
-            ntlm_compatibility=self.ntlm_compatibility
+            ntlm_compatibility=self.ntlm_compatibility,
+            strict_mode=self.ntlm_strict_mode
         )
 
         negotiate_header = ntlm_context.get_negotiate_header()

--- a/requests_ntlm2/core.py
+++ b/requests_ntlm2/core.py
@@ -1,4 +1,3 @@
-import base64
 import binascii
 import logging
 import struct
@@ -6,7 +5,6 @@ import sys
 import warnings
 
 import ntlm_auth.constants
-from aenum import IntFlag
 from cryptography import x509
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.backends import default_backend
@@ -17,50 +15,6 @@ from requests.packages.urllib3.response import HTTPResponse
 
 
 logger = logging.getLogger(__name__)
-
-
-class NegotiateFlags(IntFlag):
-    """
-    [MS-NLMP] v28.0 2016-07-14
-
-    2.2.2.5 NEGOTIATE
-    During NTLM authentication, each of the following flags is a possible value
-    of the NegotiateFlags field of the NEGOTIATE_MESSAGE, CHALLENGE_MESSAGE and
-    AUTHENTICATE_MESSAGE, unless otherwise noted. These flags define client or
-    server NTLM capabilities supported by the sender.
-    """
-    NTLMSSP_NEGOTIATE_56 = 0x80000000
-    NTLMSSP_NEGOTIATE_KEY_EXCH = 0x40000000
-    NTLMSSP_NEGOTIATE_128 = 0x20000000
-    NTLMSSP_RESERVED_R1 = 0x10000000
-    NTLMSSP_RESERVED_R2 = 0x08000000
-    NTLMSSP_RESERVED_R3 = 0x04000000
-    NTLMSSP_NEGOTIATE_VERSION = 0x02000000
-    NTLMSSP_RESERVED_R4 = 0x01000000
-    NTLMSSP_NEGOTIATE_TARGET_INFO = 0x00800000
-    NTLMSSP_REQUEST_NON_NT_SESSION_KEY = 0x00400000
-    NTLMSSP_RESERVED_R5 = 0x00200000
-    NTLMSSP_NEGOTIATE_IDENTITY = 0x00100000
-    NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY = 0x00080000
-    NTLMSSP_RESERVED_R6 = 0x00040000
-    NTLMSSP_TARGET_TYPE_SERVER = 0x00020000
-    NTLMSSP_TARGET_TYPE_DOMAIN = 0x00010000
-    NTLMSSP_NEGOTIATE_ALWAYS_SIGN = 0x00008000
-    NTLMSSP_RESERVED_R7 = 0x00004000
-    NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED = 0x00002000
-    NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED = 0x00001000
-    NTLMSSP_ANOYNMOUS = 0x00000800
-    NTLMSSP_RESERVED_R8 = 0x00000400
-    NTLMSSP_NEGOTIATE_NTLM = 0x00000200
-    NTLMSSP_RESERVED_R9 = 0x00000100
-    NTLMSSP_NEGOTIATE_LM_KEY = 0x00000080
-    NTLMSSP_NEGOTIATE_DATAGRAM = 0x00000040
-    NTLMSSP_NEGOTIATE_SEAL = 0x00000020
-    NTLMSSP_NEGOTIATE_SIGN = 0x00000010
-    NTLMSSP_RESERVED_R10 = 0x00000008
-    NTLMSSP_REQUEST_TARGET = 0x00000004
-    NTLMSSP_NEGOTIATE_OEM = 0x00000002
-    NTLMSSP_NEGOTIATE_UNICODE = 0x00000001
 
 
 class NtlmCompatibility(object):
@@ -192,12 +146,12 @@ def get_cbt_data(response):
 
 def is_challenge_message(msg):
     try:
-        message_type = struct.unpack('<I', msg[8:12])[0]
+        message_type = struct.unpack("<I", msg[8:12])[0]
         if message_type == ntlm_auth.constants.MessageTypes.NTLM_CHALLENGE:
             return True
     except struct.error:
         pass
-    logger.warning('Invalid message type: %s', msg[8:12])
+    logger.warning("Invalid message type: %s", msg[8:12])
     return False
 
 
@@ -220,25 +174,21 @@ def fix_target_info(challenge_msg):
 
     signature = msg[:8]
     if signature != ntlm_auth.constants.NTLM_SIGNATURE:
-        logger.warning('invalid signature: %r', signature)
+        logger.warning("invalid signature: %r", signature)
         return msg
 
     negotiate_flags_raw = msg[20:24]
     try:
         negotiate_flags = struct.unpack("<I", negotiate_flags_raw)[0]
     except struct.error:
-        logger.warning('Invalid Negotiate Flags: %s', negotiate_flags_raw)
+        logger.warning("Invalid Negotiate Flags: %s", negotiate_flags_raw)
         return msg
 
-    if negotiate_flags & NegotiateFlags.NTLMSSP_NEGOTIATE_TARGET_INFO:
+    if negotiate_flags & ntlm_auth.constants.NegotiateFlags.NTLMSSP_NEGOTIATE_TARGET_INFO:
         try:
-            negotiate_flags &= ~NegotiateFlags.NTLMSSP_NEGOTIATE_TARGET_INFO
-            msg = msg[:20] + struct.pack('<I', negotiate_flags.value) + msg[24:]
-            logger.debug('original challenge: %s', base64.b64encode(challenge_msg))
-            logger.debug('fixed challenge: %s', base64.b64encode(msg))
+            negotiate_flags &= ~ntlm_auth.constants.NegotiateFlags.NTLMSSP_NEGOTIATE_TARGET_INFO
+            msg = msg[:20] + struct.pack("<I", negotiate_flags) + msg[24:]
             return msg
         except struct.error:
             return challenge_msg
-    else:
-        logger.debug('no target info set')
     return challenge_msg

--- a/requests_ntlm2/dance.py
+++ b/requests_ntlm2/dance.py
@@ -107,13 +107,13 @@ class HttpNtlmContext(ntlm_auth.ntlm.NtlmContext):
     def parse_challenge_message(self, msg2):
         challenge_msg = base64.b64decode(msg2)
         if self.ntlm_strict_mode:
-            self._challenge_message = challenge_msg
+            self._challenge_token = challenge_msg
         else:
             fixed_challenge_msg = fix_target_info(challenge_msg)
             if fixed_challenge_msg != challenge_msg:
                 logger.debug("original challenge: %s", base64.b64encode(challenge_msg))
                 logger.debug("modified challenge: %s", base64.b64encode(fixed_challenge_msg))
-            self._challenge_message = fixed_challenge_msg
+            self._challenge_token = fixed_challenge_msg
 
     def create_authenticate_message(self):
         msg = self.step(self._challenge_token)

--- a/requests_ntlm2/dance.py
+++ b/requests_ntlm2/dance.py
@@ -21,7 +21,7 @@ class HttpNtlmContext(ntlm_auth.ntlm.NtlmContext):
         cbt_data=None,
         ntlm_compatibility=NtlmCompatibility.NTLMv2_DEFAULT,
         auth_type=None,
-        strict_mode=False,
+        ntlm_strict_mode=False,
     ):
         r"""
         Initialises a NTLM context to use when authenticating using the NTLM
@@ -49,8 +49,8 @@ class HttpNtlmContext(ntlm_auth.ntlm.NtlmContext):
                 3-5 : NTLMv2 Only
             Note: Values 3 to 5 are no different from a client perspective
         :param auth_type: either 'NTLM' or 'Negotiate'
-        :param strict_mode: If False, tries to Type 2 (ie challenge response) NTLM message that
-                            does not conform to the NTLM spec
+        :param ntlm_strict_mode: If False, tries to Type 2 (ie challenge response) NTLM message
+                                that does not conform to the NTLM spec
         """
         if auth_type not in ("NTLM", "Negotiate"):
             raise ValueError(
@@ -58,7 +58,7 @@ class HttpNtlmContext(ntlm_auth.ntlm.NtlmContext):
             )
         self._auth_type = auth_type
         self._challenge_token = None
-        self.strict_mode = strict_mode
+        self.ntlm_strict_mode = ntlm_strict_mode
         super(HttpNtlmContext, self).__init__(
             username,
             password,
@@ -106,13 +106,13 @@ class HttpNtlmContext(ntlm_auth.ntlm.NtlmContext):
 
     def parse_challenge_message(self, msg2):
         challenge_msg = base64.b64decode(msg2)
-        if self.strict_mode:
+        if self.ntlm_strict_mode:
             self._challenge_message = challenge_msg
         else:
             fixed_challenge_msg = fix_target_info(challenge_msg)
             if fixed_challenge_msg != challenge_msg:
-                logger.debug('original challenge: %s', base64.b64encode(challenge_msg))
-                logger.debug('modified challenge: %s', base64.b64encode(fixed_challenge_msg))
+                logger.debug("original challenge: %s", base64.b64encode(challenge_msg))
+                logger.debug("modified challenge: %s", base64.b64encode(fixed_challenge_msg))
             self._challenge_message = fixed_challenge_msg
 
     def create_authenticate_message(self):

--- a/requests_ntlm2/requests_ntlm2.py
+++ b/requests_ntlm2/requests_ntlm2.py
@@ -10,7 +10,11 @@ class HttpNtlmAuth(AuthBase):
     """
 
     def __init__(
-        self, username, password, send_cbt=True, ntlm_compatibility=NtlmCompatibility.NTLMv2_DEFAULT
+        self, username,
+        password,
+        send_cbt=True,
+        ntlm_compatibility=NtlmCompatibility.NTLMv2_DEFAULT,
+        strict_mode=False
     ):
         """Create an authentication handler for NTLM over HTTP.
 
@@ -19,6 +23,8 @@ class HttpNtlmAuth(AuthBase):
         :param bool send_cbt: Will send the channel bindings over a
                               HTTPS channel (Default: True)
         :param ntlm_compatibility: The Lan Manager Compatibility Level to use with the auth message
+        :param strict_mode: If False, tries to Type 2 (ie challenge response) NTLM message that
+                            does not conform to the NTLM spec
         """
 
         self.username, self.password, self.domain = get_ntlm_credentials(username, password)
@@ -28,6 +34,7 @@ class HttpNtlmAuth(AuthBase):
         self.password = password
         self.send_cbt = send_cbt
         self.ntlm_compatibility = ntlm_compatibility
+        self.strict_mode = strict_mode
 
         # This exposes the encrypt/decrypt methods used to encrypt and decrypt
         # messages sent after ntlm authentication. These methods are utilised
@@ -68,7 +75,8 @@ class HttpNtlmAuth(AuthBase):
             domain=self.domain,
             auth_type=auth_type,
             cbt_data=cbt_data,
-            ntlm_compatibility=self.ntlm_compatibility
+            ntlm_compatibility=self.ntlm_compatibility,
+            strict_mode=self.strict_mode
         )
         request.headers[auth_header] = ntlm_context.get_negotiate_header()
 

--- a/requests_ntlm2/requests_ntlm2.py
+++ b/requests_ntlm2/requests_ntlm2.py
@@ -14,7 +14,7 @@ class HttpNtlmAuth(AuthBase):
         password,
         send_cbt=True,
         ntlm_compatibility=NtlmCompatibility.NTLMv2_DEFAULT,
-        strict_mode=False
+        ntlm_strict_mode=False
     ):
         """Create an authentication handler for NTLM over HTTP.
 
@@ -23,8 +23,8 @@ class HttpNtlmAuth(AuthBase):
         :param bool send_cbt: Will send the channel bindings over a
                               HTTPS channel (Default: True)
         :param ntlm_compatibility: The Lan Manager Compatibility Level to use with the auth message
-        :param strict_mode: If False, tries to Type 2 (ie challenge response) NTLM message that
-                            does not conform to the NTLM spec
+        :param ntlm_strict_mode: If False, tries to Type 2 (ie challenge response) NTLM message
+                                that does not conform to the NTLM spec
         """
 
         self.username, self.password, self.domain = get_ntlm_credentials(username, password)
@@ -34,7 +34,7 @@ class HttpNtlmAuth(AuthBase):
         self.password = password
         self.send_cbt = send_cbt
         self.ntlm_compatibility = ntlm_compatibility
-        self.strict_mode = strict_mode
+        self.ntlm_strict_mode = ntlm_strict_mode
 
         # This exposes the encrypt/decrypt methods used to encrypt and decrypt
         # messages sent after ntlm authentication. These methods are utilised
@@ -76,7 +76,7 @@ class HttpNtlmAuth(AuthBase):
             auth_type=auth_type,
             cbt_data=cbt_data,
             ntlm_compatibility=self.ntlm_compatibility,
-            strict_mode=self.strict_mode
+            ntlm_strict_mode=self.ntlm_strict_mode
         )
         request.headers[auth_header] = ntlm_context.get_negotiate_header()
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ with open("README.md") as fd:
 
 
 requirements = [
-    "aenum>=2.2.3",
     "requests>=2.0.0",
     "ntlm-auth>=1.0.2",
     "cryptography>=1.3",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "6.2.4"
+version = "6.2.5"
 url = "https://github.com/dopstar/requests-ntlm2"
 
 if "a" in version:
@@ -17,6 +17,7 @@ with open("README.md") as fd:
 
 
 requirements = [
+    "aenum>=2.2.3",
     "requests>=2.0.0",
     "ntlm-auth>=1.0.2",
     "cryptography>=1.3",

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -95,7 +95,21 @@ class TestHttpNtlmAdapter(unittest.TestCase):
         self.assertIsInstance(adapter, requests_ntlm2.adapters.HttpNtlmAdapter)
         self.assertIsInstance(adapter, requests_ntlm2.adapters.HttpProxyAdapter)
         self.assertIsInstance(adapter, requests.adapters.HTTPAdapter)
-        mock_setup.assert_called_once_with("username", "password", 3)
+        mock_setup.assert_called_once_with("username", "password", 3, False)
+        mock_teardown.assert_not_called()
+
+    @mock.patch("requests_ntlm2.adapters.HttpNtlmAdapter._teardown")
+    @mock.patch("requests_ntlm2.adapters.HttpNtlmAdapter._setup")
+    def test_init__strict_mode(self, mock_setup, mock_teardown):
+        adapter = requests_ntlm2.adapters.HttpNtlmAdapter(
+            "username",
+            "password",
+            ntlm_strict_mode=True
+        )
+        self.assertIsInstance(adapter, requests_ntlm2.adapters.HttpNtlmAdapter)
+        self.assertIsInstance(adapter, requests_ntlm2.adapters.HttpProxyAdapter)
+        self.assertIsInstance(adapter, requests.adapters.HTTPAdapter)
+        mock_setup.assert_called_once_with("username", "password", 3, True)
         mock_teardown.assert_not_called()
 
     @mock.patch("requests_ntlm2.adapters.HttpNtlmAdapter._teardown")

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 
 import faker
@@ -91,3 +92,17 @@ class TestCoreFunctions(unittest.TestCase):
         response = requests_ntlm2.core.get_server_cert(raw_response)
         self.assertIsNotNone(response)
         mock_get_certificate_hash_bytes.assert_called_once()
+
+    def test_fix_challenge_message__good_message(self):
+        good_message = base64.b64decode(
+            'TlRMTVNTUAACAAAAAAAAAAAAAAAGgokA8aa4xyyducAAAAAAAAAAAAAAAAAAAAAA'
+        )
+        fixed = requests_ntlm2.core.fix_target_info(base64.b64decode(good_message))
+        self.assertEqual(fixed, good_message)
+
+    def test_fix_challenge_message__bad_message(self):
+        bad_message = base64.b64decode(
+            'TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA'
+        )
+        fixed = requests_ntlm2.core.fix_target_info(base64.b64decode(bad_message))
+        self.assertNotEqual(fixed, bad_message)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -128,6 +128,6 @@ class TestCoreFunctions(unittest.TestCase):
         bad_message = base64.b64decode(
             "TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
         )
-        self.assertTrue(requests_ntlm2.core.is_challenge_message_valid(good_message))
-        self.assertTrue(requests_ntlm2.core.is_challenge_message_valid(bad_message))
-        self.assertTrue(requests_ntlm2.core.is_challenge_message_valid(good_message[::-1]))
+        self.assertTrue(requests_ntlm2.core.is_challenge_message(good_message))
+        self.assertTrue(requests_ntlm2.core.is_challenge_message(bad_message))
+        self.assertFalse(requests_ntlm2.core.is_challenge_message(good_message[::-1]))

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -120,3 +120,14 @@ class TestCoreFunctions(unittest.TestCase):
             "TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
         )
         self.assertFalse(requests_ntlm2.core.is_challenge_message_valid(bad_message))
+
+    def test_is_challenge_message(self):
+        good_message = base64.b64decode(
+            "TlRMTVNTUAACAAAAAAAAAAAAAAAGggkAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
+        )
+        bad_message = base64.b64decode(
+            "TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
+        )
+        self.assertTrue(requests_ntlm2.core.is_challenge_message_valid(good_message))
+        self.assertTrue(requests_ntlm2.core.is_challenge_message_valid(bad_message))
+        self.assertTrue(requests_ntlm2.core.is_challenge_message_valid(good_message[::-1]))

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -95,14 +95,14 @@ class TestCoreFunctions(unittest.TestCase):
 
     def test_fix_challenge_message__good_message(self):
         good_message = base64.b64decode(
-            'TlRMTVNTUAACAAAAAAAAAAAAAAAGggkAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA'
+            "TlRMTVNTUAACAAAAAAAAAAAAAAAGggkAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
         )
         fixed = requests_ntlm2.core.fix_target_info(good_message)
         self.assertEqual(fixed, good_message)
 
     def test_fix_challenge_message__bad_message(self):
         bad_message = base64.b64decode(
-            'TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA'
+            "TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
         )
         fixed = requests_ntlm2.core.fix_target_info(bad_message)
         self.assertNotEqual(fixed, bad_message)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -97,12 +97,12 @@ class TestCoreFunctions(unittest.TestCase):
         good_message = base64.b64decode(
             'TlRMTVNTUAACAAAAAAAAAAAAAAAGgokA8aa4xyyducAAAAAAAAAAAAAAAAAAAAAA'
         )
-        fixed = requests_ntlm2.core.fix_target_info(base64.b64decode(good_message))
+        fixed = requests_ntlm2.core.fix_target_info(good_message)
         self.assertEqual(fixed, good_message)
 
     def test_fix_challenge_message__bad_message(self):
         bad_message = base64.b64decode(
             'TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA'
         )
-        fixed = requests_ntlm2.core.fix_target_info(base64.b64decode(bad_message))
+        fixed = requests_ntlm2.core.fix_target_info(bad_message)
         self.assertNotEqual(fixed, bad_message)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -95,7 +95,7 @@ class TestCoreFunctions(unittest.TestCase):
 
     def test_fix_challenge_message__good_message(self):
         good_message = base64.b64decode(
-            'TlRMTVNTUAACAAAAAAAAAAAAAAAGgokA8aa4xyyducAAAAAAAAAAAAAAAAAAAAAA'
+            'TlRMTVNTUAACAAAAAAAAAAAAAAAGggkAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA'
         )
         fixed = requests_ntlm2.core.fix_target_info(good_message)
         self.assertEqual(fixed, good_message)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -93,16 +93,30 @@ class TestCoreFunctions(unittest.TestCase):
         self.assertIsNotNone(response)
         mock_get_certificate_hash_bytes.assert_called_once()
 
-    def test_fix_challenge_message__good_message(self):
+    def test_fix_challenge_message(self):
         good_message = base64.b64decode(
             "TlRMTVNTUAACAAAAAAAAAAAAAAAGggkAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
         )
         fixed = requests_ntlm2.core.fix_target_info(good_message)
         self.assertEqual(fixed, good_message)
 
-    def test_fix_challenge_message__bad_message(self):
         bad_message = base64.b64decode(
             "TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
         )
         fixed = requests_ntlm2.core.fix_target_info(bad_message)
         self.assertNotEqual(fixed, bad_message)
+
+        very_bad_message = bad_message[::-1]
+        result = requests_ntlm2.core.fix_target_info(very_bad_message)
+        self.assertEqual(result, very_bad_message)
+
+    def test_is_challenge_message_valid(self):
+        good_message = base64.b64decode(
+            "TlRMTVNTUAACAAAAAAAAAAAAAAAGggkAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
+        )
+        self.assertTrue(requests_ntlm2.core.is_challenge_message_valid(good_message))
+
+        bad_message = base64.b64decode(
+            "TlRMTVNTUAACAAAAAAAAAAAAAAAGgokAmuCpt5hD4IIAAAAAAAAAAAAAAAAAAAAA"
+        )
+        self.assertFalse(requests_ntlm2.core.is_challenge_message_valid(bad_message))


### PR DESCRIPTION
by default strict mode is disabled and Type 2 (challenge) messages
from the server that have negotiate flags for target info (only target info for now)
and have no target info data (this violates the NTLM spec) will be modified by
unsetting the target info flag from the negotiate bit flags

for further explanation, see: https://github.com/jborean93/ntlm-auth/issues/10