### PR TITLE
Use system install of six

### DIFF
--- a/requests_ntlm2/connection.py
+++ b/requests_ntlm2/connection.py
@@ -2,14 +2,15 @@ import logging
 import re
 import socket
 
+from six.moves.http_client import (
+    PROXY_AUTHENTICATION_REQUIRED,
+    LineTooLong
+)
+
 from requests.packages.urllib3.connection import DummyConnection
 from requests.packages.urllib3.connection import HTTPConnection as _HTTPConnection
 from requests.packages.urllib3.connection import HTTPSConnection as _HTTPSConnection
 from requests.packages.urllib3.connection import VerifiedHTTPSConnection as _VerifiedHTTPSConnection
-from requests.packages.urllib3.packages.six.moves.http_client import (
-    PROXY_AUTHENTICATION_REQUIRED,
-    LineTooLong
-)
 
 from .core import NtlmCompatibility, get_ntlm_credentials
 from .dance import HttpNtlmContext

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ requirements = [
     "requests>=2.0.0",
     "ntlm-auth>=1.0.2",
     "cryptography>=1.3",
+    "six>=1.10",
 ]
 
 testing_requirements = [


### PR DESCRIPTION
Was relying on six.py embedded in urllib3. Some distributions remove
and patch urllib3. This breaks requests-ntlm2 since it can no longer
find six.py at requests.packages.urllib3.packages.six.

Closes #17 