### PR TITLE
Proxy response blocking because of different end of file formats.

### DIFF
--- a/requests_ntlm2/connection.py
+++ b/requests_ntlm2/connection.py
@@ -1,7 +1,7 @@
 import logging
 import re
-import socket
 import select
+import socket
 
 from requests.packages.urllib3.connection import DummyConnection
 from requests.packages.urllib3.connection import HTTPConnection as _HTTPConnection

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ testing_requirements = [
 
 linting_requirements = [
     "flake8",
-    "bandit",
+    "bandit==1.6.2; python_version == '2.7'",
+    "bandit; python_version != '2.7'",
     "flake8-isort",
     "flake8-quotes",
 ]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "6.2.8"
+version = "6.2.9"
 url = "https://github.com/dopstar/requests-ntlm2"
 
 if "a" in version:


### PR DESCRIPTION
Related to #19 and #20 .

Testing the #20 solution to BadStatusLine errors arising after Squid responses, I found another problem while using a MacAfee Proxy with an NTLM Agent.

The MacAfee Proxy was not sending the same new lines as the Squid proxy so the fix in #20 was blocking the process during response processing.

This PR aims to support both formats using `select` to determine if the socket file descriptor is available for read or not. It has a timeout fallback to prevent blocking the response processing that assumes the response was read completely.

If you need any extra information feel free to message me :)

Cheers!
