### PR TITLE
fix proxy tunnelling regression issue

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+#### 6.4.2 - 04 Aug 2021
+ - fix regression issue introduced in https://github.com/dopstar/requests-ntlm2/pull/21
+ - include `workstation` name (ie hostname) in the NTLM dance
+
 #### 6.4.1 - 02 Aug 2021
  - fix python2 max-int bug introduced by version 6.4.0
 

--- a/requests_ntlm2/core.py
+++ b/requests_ntlm2/core.py
@@ -28,7 +28,7 @@ class NtlmCompatibility(object):
     NTLMv2_LEVEL5 = 5
 
 
-class NtlmFlags(IntFlag):
+class NegotiateFlags(IntFlag):
     # Indicates that Unicode strings are supported for use
     # in security buffer data.
     NEGOTIATE_UNICODE = 0x00000001
@@ -154,7 +154,7 @@ _DYNAMIC_NTLM_FLAGS = {
 
 for k, v in _DYNAMIC_NTLM_FLAGS.items():
     try:
-        extend_enum(NtlmFlags, k, v)
+        extend_enum(NegotiateFlags, k, v)
     except OverflowError:
         logger.warning("not defining '%s.%s' enum member because its beyond maxint")
 

--- a/requests_ntlm2/dance.py
+++ b/requests_ntlm2/dance.py
@@ -4,7 +4,7 @@ import logging
 import ntlm_auth.messages
 import ntlm_auth.ntlm
 
-from .core import NtlmCompatibility, NtlmFlags, fix_target_info
+from .core import NegotiateFlags, NtlmCompatibility, fix_target_info
 
 
 logger = logging.getLogger(__name__)
@@ -109,7 +109,9 @@ class HttpNtlmContext(ntlm_auth.ntlm.NtlmContext):
         challenge_msg = base64.b64decode(msg2)
 
         try:
-            flags = NtlmFlags(ntlm_auth.messages.ChallengeMessage(challenge_msg).negotiate_flags)
+            flags = NegotiateFlags(
+                ntlm_auth.messages.ChallengeMessage(challenge_msg).negotiate_flags
+            )
             logger.debug("challenge flags: %s", flags)
         except Exception:
             logger.exception("unable to check challenge flags; e=")

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "6.4.1"
+version = "6.4.2"
 url = "https://github.com/dopstar/requests-ntlm2"
 
 if "a" in version:

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -78,15 +78,15 @@ class TestHttpProxyAdapter(object):
         assert adapter.add_headers(request) is None
         mock_add_host_header.assert_called_once_with(request)
 
-    @mock.patch("requests.adapters.HTTPAdapter.proxy_headers", return_value={'foo': 'bar'})
+    @mock.patch("requests.adapters.HTTPAdapter.proxy_headers", return_value={"foo": "bar"})
     def test_proxy_headers(self, mock_proxy_headers):
         adapter = requests_ntlm2.adapters.HttpProxyAdapter()
         assert adapter.proxy_headers({}) == {"foo": "bar"}
         mock_proxy_headers.assert_called_once_with({})
 
-    @mock.patch("requests.adapters.HTTPAdapter.proxy_headers", return_value={'foo': 'bar'})
+    @mock.patch("requests.adapters.HTTPAdapter.proxy_headers", return_value={"foo": "bar"})
     def test_proxy_headers__with_user_agent(self, mock_proxy_headers):
-        adapter = requests_ntlm2.adapters.HttpProxyAdapter(user_agent='fake-ua/1.0')
+        adapter = requests_ntlm2.adapters.HttpProxyAdapter(user_agent="fake-ua/1.0")
         assert adapter.proxy_headers({"this": "that"}) == {
             "foo": "bar",
             "User-Agent": "fake-ua/1.0"


### PR DESCRIPTION
https://github.com/dopstar/requests-ntlm2/pull/21 introduced a regression where reading from the socket during proxy tunneling would block indefinitely resulting in proxy tunneling to timeout (and hence fail to be established).

these changes remove that regression by partial reverting the parts of the offending code. 