### PR TITLE
rework draining the response socket during proxy tunnelling

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+#### [6.5.2](https://github.com/dopstar/requests-ntlm2/releases/tag/6.5.2) - 24 Oct 2022
+ - reworked draining the response socket when establishing proxy tunnelling - https://github.com/dopstar/requests-ntlm2/pull/39
+
 #### [6.5.1](https://github.com/dopstar/requests-ntlm2/releases/tag/6.5.1) - 20 Oct 2022
  - be more defensive while parsing the response HTML during proxy tunnelling - https://github.com/dopstar/requests-ntlm2/pull/37
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-version = "6.5.1"
+version = "6.5.2"
 url = "https://github.com/dopstar/requests-ntlm2"
 
 if "a" in version:

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -139,6 +139,7 @@ class TestVerifiedHTTPSConnection(unittest.TestCase):
     @mock.patch("requests_ntlm2.connection.VerifiedHTTPSConnection.send")
     def test__tunnel__line_too_long(self, mock_send, mock_get_response, mock_select):
         fp = BytesIO(
+            b"Info: x%s\r\n"
             b"Proxy-Authenticate: NTLM TlRMTVNTUAACAAAABgAGADgAAAAGgokAyYpGWqVMA/QAAAAAAAAA"
             b"AH4AfgA+AAAABQCTCAAAAA9ERVROU1cCAAwARABFAFQATgBTAFcAAQAaAFMARwAtADQAOQAxADMAM"
             b"wAwADAAMAAwADkABAAUAEQARQBUAE4AUwBXAC4AVwBJAE4AAwAwAHMAZwAtADQAOQAxADMAMwAwAD"
@@ -146,7 +147,6 @@ class TestVerifiedHTTPSConnection(unittest.TestCase):
             b"Connection: Keep-Alive\r\n"
             b"Proxy-Connection: Keep-Alive\r\n"
             b"Server: nginx\r\n"
-            b"Info: x%s\r\n"
             b"\r\n"
             b"this is the body\r\n"
             b"\r\n" % (b"x" * _MAXLINE)


### PR DESCRIPTION
reworked the logic to drain the response socket during proxy tunneling to no longer rely on the Content-Length header as that is not reliable (observed cases where available bytes of the body (html) are fewer than what is on content-length, due to possibly HTTP/1.1 chunking. Wireshark would show `Continuation` packets which then add up to the Content-Length when concatenated).

The logic to drain the socket during proxy tunnel establishment is now as follows:
- if the read line from the response socket is the NTLM Challenge Message (ie [NTLM Type 2 Message](https://davenport.sourceforge.net/ntlm.html#theType2Message)), then drain socket
- if two consecutive blank lines are detected, drain the socket. note that the header is separated from the body by a blank line so any presence of a blank line means that the next thing afterwards cannot be an HTML header. if the NTLM Challenge message has not been received at this point, tunneling will fail anyway since NTLM handshake will fail. 
